### PR TITLE
Use xbmcvfs for translatePath

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.plexkodiconnect.tvshows" name="PlexKodiConnect Helper TV Shows" version="3.0.0" provider-name="croneter">
+<addon id="plugin.video.plexkodiconnect.tvshows" name="PlexKodiConnect Helper TV Shows" version="3.0.1" provider-name="croneter">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>

--- a/default.py
+++ b/default.py
@@ -6,7 +6,7 @@ from logging import getLogger
 import sys
 import os
 
-import xbmc
+import xbmcvfs
 import xbmcgui
 import xbmcplugin
 import xbmcaddon
@@ -14,7 +14,7 @@ import xbmcaddon
 # Import from the main pkc add-on
 __addon__ = xbmcaddon.Addon(id='plugin.video.plexkodiconnect')
 __temp_path__ = os.path.join(__addon__.getAddonInfo('path'), 'resources', 'lib')
-__base__ = xbmc.translatePath(__temp_path__.encode('utf-8'))
+__base__ = xbmcvfs.translatePath(__temp_path__.encode('utf-8'))
 sys.path.append(__base__)
 
 import transfer, loghandler


### PR DESCRIPTION
This seems to have been removed in Kodi 20 nightly, and the current code makes PKC fail playback.